### PR TITLE
Allow configuring task schedules on a per-instance basis

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use persistent_scheduler::core::{
-    context::{TaskAndDelay, TaskContext},
+    context::{TaskConfiguration, TaskContext},
     store::InMemoryTaskStore,
     task::{Task, TaskFuture},
     task_kind::TaskKind,
@@ -23,8 +23,9 @@ async fn main() {
         .await;
     let mut tasks = Vec::new();
     for _ in 0..100 {
-        tasks.push(TaskAndDelay {
+        tasks.push(TaskConfiguration {
             inner: MyTask1::new("name1".to_string(), 32),
+            kind: TaskKind::Once,
             delay_seconds: None,
         });
     }
@@ -53,9 +54,6 @@ impl Task for MyTask1 {
 
     const TASK_QUEUE: &'static str = "default";
 
-    const TASK_KIND: TaskKind = TaskKind::Once;
-    //const RETRY_POLICY: RetryPolicy = RetryPolicy::linear(10, Some(5));
-
     fn run(self) -> TaskFuture {
         Box::pin(async move {
             // println!("{}", self.name);
@@ -82,9 +80,6 @@ impl MyTask2 {
 impl Task for MyTask2 {
     const TASK_KEY: &'static str = "my_task_b";
     const TASK_QUEUE: &'static str = "default";
-    const TASK_KIND: TaskKind = TaskKind::Repeat {
-        interval_seconds: 10
-    };
 
     fn run(self) -> TaskFuture {
         Box::pin(async move {

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -82,10 +82,9 @@ impl MyTask2 {
 impl Task for MyTask2 {
     const TASK_KEY: &'static str = "my_task_b";
     const TASK_QUEUE: &'static str = "default";
-    const TASK_KIND: TaskKind = TaskKind::Repeat;
-    const REPEAT_INTERVAL: Option<u32> = Some(10);
-    //const SCHEDULE: Option<&'static str> = Some("1/10 * * * * *");
-    //const TIMEZONE: Option<&'static str> = Some("Asia/Shanghai");
+    const TASK_KIND: TaskKind = TaskKind::Repeat {
+        interval_seconds: 10
+    };
 
     fn run(self) -> TaskFuture {
         Box::pin(async move {

--- a/examples/nativedb.rs
+++ b/examples/nativedb.rs
@@ -1,7 +1,7 @@
 use std::{sync::Arc, time::Duration};
 use persistent_scheduler::{
     core::{
-        context::{TaskAndDelay, TaskContext},
+        context::{TaskConfiguration, TaskContext},
         store::TaskStore,
         task::{Task, TaskFuture},
         task_kind::TaskKind,
@@ -27,8 +27,9 @@ async fn main() {
     let mut tasks = Vec::new();
 
     for _ in 0..10000 {
-        tasks.push(TaskAndDelay {
+        tasks.push(TaskConfiguration {
             inner: MyTask1::new("name1".to_string(), 32),
+            kind: TaskKind::Once,
             delay_seconds: None,
         });
     }
@@ -57,7 +58,6 @@ impl Task for MyTask1 {
 
     const TASK_QUEUE: &'static str = "default";
 
-    const TASK_KIND: TaskKind = TaskKind::Once;
     //const RETRY_POLICY: RetryPolicy = RetryPolicy::linear(10, Some(5));
     const DELAY_SECONDS: u32 = 0;
     fn run(self) -> TaskFuture {
@@ -86,10 +86,6 @@ impl MyTask2 {
 impl Task for MyTask2 {
     const TASK_KEY: &'static str = "my_task_c";
     const TASK_QUEUE: &'static str = "default";
-    const TASK_KIND: TaskKind = TaskKind::Cron {
-        schedule: "1/2 * * * * *",
-        timezone: "Asia/Shanghai"
-    };
 
     fn run(self) -> TaskFuture {
         Box::pin(async move {

--- a/examples/nativedb.rs
+++ b/examples/nativedb.rs
@@ -1,5 +1,4 @@
 use std::{sync::Arc, time::Duration};
-
 use persistent_scheduler::{
     core::{
         context::{TaskAndDelay, TaskContext},
@@ -87,10 +86,10 @@ impl MyTask2 {
 impl Task for MyTask2 {
     const TASK_KEY: &'static str = "my_task_c";
     const TASK_QUEUE: &'static str = "default";
-    const TASK_KIND: TaskKind = TaskKind::Cron;
-    const REPEAT_INTERVAL: Option<u32> = Some(2);
-    const SCHEDULE: Option<&'static str> = Some("1/2 * * * * *");
-    const TIMEZONE: Option<&'static str> = Some("Asia/Shanghai");
+    const TASK_KIND: TaskKind = TaskKind::Cron {
+        schedule: "1/2 * * * * *",
+        timezone: "Asia/Shanghai"
+    };
 
     fn run(self) -> TaskFuture {
         Box::pin(async move {

--- a/src/core/model.rs
+++ b/src/core/model.rs
@@ -6,6 +6,8 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 use std::fmt;
+use crate::core::task_kind::TaskKind;
+
 type LinearInterval = u32;
 type ExponentialBase = u32;
 
@@ -32,28 +34,6 @@ pub struct TaskMeta {
     pub max_retries: Option<u32>,       // Maximum number of retries allowed
     pub is_repeating: bool,             // Indicates if the task is repeating
     pub heartbeat_at: i64,              // Timestamp of the last heartbeat in milliseconds
-}
-
-#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
-/// Defines the type of task to be executed.
-pub enum TaskKind {
-    /// Represents a cron job, which is scheduled to run at specific intervals.
-    Cron {
-        /// Schedule expression for Cron tasks.
-        schedule: String,
-        /// Timezone for the schedule expression.
-        timezone: String,
-    },
-
-    /// Represents a repeated job that runs at a regular interval.
-    Repeat {
-        /// Repeat interval for Repeat tasks, in seconds.
-        interval_seconds: u32
-    },
-
-    /// Represents a one-time job that runs once and then completes.
-    #[default]
-    Once,
 }
 
 #[derive(Clone, Debug, Eq, Default, PartialEq, Serialize, Deserialize, Hash)]

--- a/src/core/model.rs
+++ b/src/core/model.rs
@@ -1,7 +1,6 @@
 use crate::{
     core::{
         retry::{RetryPolicy, RetryStrategy},
-        task_kind::TaskKind,
     },
     generate_token, utc_now,
 };
@@ -31,11 +30,30 @@ pub struct TaskMeta {
     pub base_interval: u32,             // Base interval for exponential backoff
     pub delay_seconds: u32,             //Delay before executing a Once task, specified in seconds
     pub max_retries: Option<u32>,       // Maximum number of retries allowed
-    pub cron_schedule: Option<String>,  // Cron expression for scheduling
-    pub cron_timezone: Option<String>,  // Timezone for the cron schedule (stored as a string)
     pub is_repeating: bool,             // Indicates if the task is repeating
-    pub repeat_interval: u32,           // Interval for repeating task
     pub heartbeat_at: i64,              // Timestamp of the last heartbeat in milliseconds
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+/// Defines the type of task to be executed.
+pub enum TaskKind {
+    /// Represents a cron job, which is scheduled to run at specific intervals.
+    Cron {
+        /// Schedule expression for Cron tasks.
+        schedule: String,
+        /// Timezone for the schedule expression.
+        timezone: String,
+    },
+
+    /// Represents a repeated job that runs at a regular interval.
+    Repeat {
+        /// Repeat interval for Repeat tasks, in seconds.
+        interval_seconds: u32
+    },
+
+    /// Represents a one-time job that runs once and then completes.
+    #[default]
+    Once,
 }
 
 #[derive(Clone, Debug, Eq, Default, PartialEq, Serialize, Deserialize, Hash)]
@@ -104,18 +122,11 @@ impl TaskMeta {
         queue_name: String,
         kind: TaskKind,
         retry_policy: RetryPolicy,
-        cron_schedule: Option<String>,
-        cron_timezone: Option<String>,
         is_repeating: bool,
-        repeat_interval: Option<u32>,
         delay_seconds: u32,
     ) -> Self {
         // Extract retry strategy and intervals from the given retry policy.
         let (retry_strategy, retry_interval, base_interval) = to_retry(retry_policy);
-        let repeat_interval = match repeat_interval {
-            Some(v) => v,
-            None => Default::default(),
-        };
         Self {
             id: generate_token!(),
             task_key,
@@ -135,10 +146,7 @@ impl TaskMeta {
             retry_interval,
             base_interval,
             max_retries: retry_policy.max_retries,
-            cron_schedule,
-            cron_timezone,
             is_repeating,
-            repeat_interval,
             heartbeat_at: Default::default(),
             delay_seconds,
         }

--- a/src/core/status_updater.rs
+++ b/src/core/status_updater.rs
@@ -1,9 +1,10 @@
 use crate::core::{
-    cron::next_run, model::TaskMeta, result::TaskResult, store::TaskStore, model::TaskKind,
+    cron::next_run, model::TaskMeta, result::TaskResult, store::TaskStore
 };
 use std::sync::Arc;
 use tokio::sync::mpsc;
 use tracing::error;
+use crate::core::task_kind::TaskKind;
 
 #[derive(Debug)]
 pub enum UpdateRequest {

--- a/src/core/store.rs
+++ b/src/core/store.rs
@@ -1,5 +1,5 @@
 use crate::{
-    core::model::{TaskKind, TaskMeta, TaskStatus},
+    core::model::{TaskMeta, TaskStatus},
     utc_now,
 };
 use ahash::AHashMap;
@@ -7,6 +7,7 @@ use async_trait::async_trait;
 use std::{error::Error, sync::Arc};
 use thiserror::Error;
 use tokio::sync::RwLock;
+use crate::core::task_kind::TaskKind;
 
 #[async_trait::async_trait]
 pub trait TaskStore: Clone + Send {

--- a/src/core/store.rs
+++ b/src/core/store.rs
@@ -1,6 +1,5 @@
-use crate::core::task_kind::TaskKind;
 use crate::{
-    core::model::{TaskMeta, TaskStatus},
+    core::model::{TaskKind, TaskMeta, TaskStatus},
     utc_now,
 };
 use ahash::AHashMap;
@@ -171,7 +170,7 @@ impl InMemoryTaskStore {
 /// Determines if a task can be executed based on its kind and status.
 pub fn is_candidate_task(kind: &TaskKind, status: &TaskStatus) -> bool {
     match kind {
-        TaskKind::Cron | TaskKind::Repeat => matches!(
+        TaskKind::Cron { .. } | TaskKind::Repeat { .. } => matches!(
             status,
             TaskStatus::Scheduled | TaskStatus::Success | TaskStatus::Failed
         ),

--- a/src/core/task_kind.rs
+++ b/src/core/task_kind.rs
@@ -4,10 +4,18 @@ use serde::{Deserialize, Serialize};
 /// Defines the type of task to be executed.
 pub enum TaskKind {
     /// Represents a cron job, which is scheduled to run at specific intervals.
-    Cron,
+    Cron {
+        /// Schedule expression for Cron tasks.
+        schedule: &'static str,
+        /// Timezone for the schedule expression.
+        timezone: &'static str,
+    },
 
     /// Represents a repeated job that runs at a regular interval.
-    Repeat,
+    Repeat {
+        /// Repeat interval for Repeat tasks, in seconds.
+        interval_seconds: u32
+    },
 
     /// Represents a one-time job that runs once and then completes.
     #[default]
@@ -17,8 +25,8 @@ pub enum TaskKind {
 impl std::fmt::Display for TaskKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            TaskKind::Cron => write!(f, "Cron"),
-            TaskKind::Repeat => write!(f, "Repeat"),
+            TaskKind::Cron { .. } => write!(f, "Cron"),
+            TaskKind::Repeat { .. } => write!(f, "Repeat"),
             TaskKind::Once => write!(f, "Once"),
         }
     }

--- a/src/core/task_kind.rs
+++ b/src/core/task_kind.rs
@@ -6,9 +6,9 @@ pub enum TaskKind {
     /// Represents a cron job, which is scheduled to run at specific intervals.
     Cron {
         /// Schedule expression for Cron tasks.
-        schedule: &'static str,
+        schedule: String,
         /// Timezone for the schedule expression.
-        timezone: &'static str,
+        timezone: String,
     },
 
     /// Represents a repeated job that runs at a regular interval.

--- a/src/nativedb/meta.rs
+++ b/src/nativedb/meta.rs
@@ -3,7 +3,6 @@ use crate::core::model::TaskMeta;
 use crate::core::model::TaskStatus;
 use crate::core::store::is_candidate_task;
 use crate::core::store::TaskStore;
-use crate::core::model::TaskKind;
 use crate::nativedb::get_database;
 use crate::nativedb::init_nativedb;
 use crate::nativedb::TaskMetaEntity;
@@ -16,6 +15,7 @@ use std::sync::Arc;
 use std::time::Instant;
 use thiserror::Error;
 use tracing::debug;
+use crate::core::task_kind::TaskKind;
 
 #[derive(Error, Debug)]
 pub enum NativeDbTaskStoreError {

--- a/src/nativedb/mod.rs
+++ b/src/nativedb/mod.rs
@@ -1,12 +1,12 @@
 use crate::core::error::SchedulerError;
 use crate::core::model::{Retry, TaskMeta, TaskStatus};
-use crate::core::model::TaskKind;
 use native_db::*;
 use native_model::native_model;
 use native_model::Model;
 use serde::{Deserialize, Serialize};
 use std::sync::{LazyLock, OnceLock};
 use tracing::error;
+use crate::core::task_kind::TaskKind;
 
 pub mod meta;
 #[cfg(test)]

--- a/src/nativedb/mod.rs
+++ b/src/nativedb/mod.rs
@@ -56,7 +56,7 @@ pub fn get_database() -> Result<&'static Database<'static>, SchedulerError> {
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
-#[native_model(id = 1, version = 2)]
+#[native_model(id = 1, version = 1)]
 #[native_db(secondary_key(clean_up -> String), secondary_key(candidate_task -> String))]
 pub struct TaskMetaEntity {
     #[primary_key]
@@ -72,7 +72,7 @@ pub struct TaskMetaEntity {
     pub last_error: Option<String>, // Error message from the last execution, if any
     pub last_run: i64,       // Timestamp of the last run
     pub next_run: i64,       // Timestamp of the next scheduled run
-    pub kind: TaskKind,      // Type of the task
+    pub kind: TaskKindEntity,      // Type of the task
     pub success_count: u32,  // Count of successful runs
     pub failure_count: u32,  // Count of failed runs
     pub runner_id: Option<String>, // The ID of the current task runner, may be None
@@ -81,15 +81,32 @@ pub struct TaskMetaEntity {
     pub base_interval: u32,  // Base interval for exponential backoff
     pub delay_seconds: u32,  //Delay before executing a Once task, specified in seconds
     pub max_retries: Option<u32>, // Maximum number of retries allowed
+    pub cron_schedule: Option<String>, // Cron expression for scheduling
+    pub cron_timezone: Option<String>, // Timezone for the cron schedule (stored as a string)
     pub is_repeating: bool,  // Indicates if the task is repeating
+    pub repeat_interval: u32, // Interval for repeating task
     pub heartbeat_at: i64,   // Timestamp of the last heartbeat in milliseconds
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+/// Defines the type of task to be executed.
+pub enum TaskKindEntity {
+    /// Represents a cron job, which is scheduled to run at specific intervals.
+    Cron,
+
+    /// Represents a repeated job that runs at a regular interval.
+    Repeat,
+
+    /// Represents a one-time job that runs once and then completes.
+    #[default]
+    Once,
 }
 
 impl TaskMetaEntity {
     pub fn clean_up(&self) -> String {
         let result = match self.kind {
-            TaskKind::Cron { .. } | TaskKind::Repeat { .. } => matches!(self.status, TaskStatus::Removed),
-            TaskKind::Once => matches!(
+            TaskKindEntity::Cron | TaskKindEntity::Repeat => matches!(self.status, TaskStatus::Removed),
+            TaskKindEntity::Once => matches!(
                 self.status,
                 TaskStatus::Removed | TaskStatus::Success | TaskStatus::Failed
             ),
@@ -99,11 +116,11 @@ impl TaskMetaEntity {
 
     pub fn candidate_task(&self) -> String {
         let result = match self.kind {
-            TaskKind::Cron { .. } | TaskKind::Repeat { .. } => matches!(
+            TaskKindEntity::Cron | TaskKindEntity::Repeat => matches!(
                 self.status,
                 TaskStatus::Scheduled | TaskStatus::Success | TaskStatus::Failed
             ),
-            TaskKind::Once => self.status == TaskStatus::Scheduled,
+            TaskKindEntity::Once => self.status == TaskStatus::Scheduled,
         };
         result.to_string()
     }
@@ -122,7 +139,16 @@ impl From<TaskMetaEntity> for TaskMeta {
             last_error: entity.last_error,
             last_run: entity.last_run,
             next_run: entity.next_run,
-            kind: entity.kind,
+            kind: match entity.kind {
+                TaskKindEntity::Cron => TaskKind::Cron {
+                    schedule: entity.cron_schedule.expect("Cron schedule is required for cron kind!"),
+                    timezone: entity.cron_timezone.expect("Cron timezone is required for cron kind!"),
+                },
+                TaskKindEntity::Repeat => TaskKind::Repeat {
+                    interval_seconds: entity.repeat_interval,
+                },
+                TaskKindEntity::Once => TaskKind::Once
+            },
             success_count: entity.success_count,
             failure_count: entity.failure_count,
             runner_id: entity.runner_id,
@@ -139,6 +165,32 @@ impl From<TaskMetaEntity> for TaskMeta {
 
 impl From<TaskMeta> for TaskMetaEntity {
     fn from(entity: TaskMeta) -> Self {
+        let kind;
+        let cron_schedule;
+        let cron_timezone;
+        let repeat_interval;
+
+        match entity.kind {
+            TaskKind::Cron { schedule, timezone } => {
+                kind = TaskKindEntity::Cron;
+                cron_schedule = Some(schedule);
+                cron_timezone = Some(timezone);
+                repeat_interval = 0;
+            }
+            TaskKind::Repeat { interval_seconds } => {
+                kind = TaskKindEntity::Repeat;
+                cron_schedule = None;
+                cron_timezone = None;
+                repeat_interval = interval_seconds;
+            }
+            TaskKind::Once => {
+                kind = TaskKindEntity::Once;
+                cron_schedule = None;
+                cron_timezone = None;
+                repeat_interval = 0;
+            }
+        }
+
         TaskMetaEntity {
             id: entity.id,
             task_key: entity.task_key,
@@ -150,7 +202,7 @@ impl From<TaskMeta> for TaskMetaEntity {
             last_error: entity.last_error,
             last_run: entity.last_run,
             next_run: entity.next_run,
-            kind: entity.kind,
+            kind,
             success_count: entity.success_count,
             failure_count: entity.failure_count,
             runner_id: entity.runner_id,
@@ -159,7 +211,10 @@ impl From<TaskMeta> for TaskMetaEntity {
             base_interval: entity.base_interval,
             delay_seconds: entity.delay_seconds,
             max_retries: entity.max_retries,
+            cron_schedule,
+            cron_timezone,
             is_repeating: entity.is_repeating,
+            repeat_interval,
             heartbeat_at: entity.heartbeat_at,
         }
     }

--- a/src/nativedb/tests.rs
+++ b/src/nativedb/tests.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 use native_db::Builder;
 
-use crate::{core::{model::TaskStatus, task_kind::TaskKind}, generate_token};
+use crate::{core::{model::TaskStatus, model::TaskKind}, generate_token};
 
 use super::{TaskMetaEntity, TaskMetaEntityKey, TASK_SCHEDULER_MODELS};
 
@@ -23,7 +23,7 @@ fn test() {
     let mut task3 = TaskMetaEntity::default();
     task3.id = generate_token!();
     task3.status = TaskStatus::Failed;
-    task3.kind = TaskKind::Cron;
+    task3.kind = TaskKind::Cron { schedule: "5 4 * * *".into(), timezone: "UTC".into() };
 
     rw.insert(task1).unwrap();
     rw.insert(task2).unwrap();

--- a/src/nativedb/tests.rs
+++ b/src/nativedb/tests.rs
@@ -1,8 +1,8 @@
 use itertools::Itertools;
 use native_db::Builder;
 
-use crate::{core::{model::TaskStatus, model::TaskKind}, generate_token};
-
+use crate::{core::model::TaskStatus, generate_token};
+use crate::core::task_kind::TaskKind;
 use super::{TaskMetaEntity, TaskMetaEntityKey, TASK_SCHEDULER_MODELS};
 
 #[test]

--- a/src/nativedb/tests.rs
+++ b/src/nativedb/tests.rs
@@ -2,8 +2,7 @@ use itertools::Itertools;
 use native_db::Builder;
 
 use crate::{core::model::TaskStatus, generate_token};
-use crate::core::task_kind::TaskKind;
-use super::{TaskMetaEntity, TaskMetaEntityKey, TASK_SCHEDULER_MODELS};
+use super::{TaskKindEntity, TaskMetaEntity, TaskMetaEntityKey, TASK_SCHEDULER_MODELS};
 
 #[test]
 fn test() {
@@ -23,7 +22,7 @@ fn test() {
     let mut task3 = TaskMetaEntity::default();
     task3.id = generate_token!();
     task3.status = TaskStatus::Failed;
-    task3.kind = TaskKind::Cron { schedule: "5 4 * * *".into(), timezone: "UTC".into() };
+    task3.kind = TaskKindEntity::Cron;
 
     rw.insert(task1).unwrap();
     rw.insert(task2).unwrap();


### PR DESCRIPTION
Instead of configuring scheduling on a per-`struct` basis, scheduling is configured for each instance of said struct. As an example, I could have a `SyncDataTask`, and configure two instances of that task to run on different intervals, one every day at midnight and the other every hour.

I'm fairly sure this is _not_ a breaking change in terms of the native DB store (so existing tasks will continue to behave correctly), but it's definitely a breaking change for task creation.

Resolves #1 